### PR TITLE
Adding verifiedChains details to ClientTls

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -11,7 +11,7 @@ plugins {
     id 'signing'
 }
 
-def jarVersion = "2.1.1"
+def jarVersion = "2.1.2"
 group = 'io.nats'
 
 def isMerge = System.getenv("BUILD_EVENT") == "push"

--- a/build.gradle
+++ b/build.gradle
@@ -11,7 +11,7 @@ plugins {
     id 'signing'
 }
 
-def jarVersion = "2.1.2"
+def jarVersion = "2.1.1"
 group = 'io.nats'
 
 def isMerge = System.getenv("BUILD_EVENT") == "push"

--- a/src/main/java/io/nats/jwt/ClientTls.java
+++ b/src/main/java/io/nats/jwt/ClientTls.java
@@ -20,6 +20,7 @@ import io.nats.json.JsonWriteUtils;
 
 import java.util.List;
 import java.util.Objects;
+import java.util.stream.Collectors;
 
 import static io.nats.json.JsonWriteUtils.beginJson;
 import static io.nats.json.JsonWriteUtils.endJson;
@@ -38,7 +39,7 @@ public class ClientTls implements JsonSerializable {
         version = JsonValueUtils.readString(jv, "version");
         cipher = JsonValueUtils.readString(jv, "cipher");
         certs = JsonValueUtils.readOptionalStringList(jv, "certs");
-        verifiedChains = null; // TODO verified_chains
+        verifiedChains = JsonValueUtils.readArray(jv, "verified_chains").stream().map(jsonObj -> JsonValueUtils.listOf(jsonObj, JsonValue::toJson)).collect(Collectors.toList());
     }
 
     @Override

--- a/src/test/java/io/nats/client/support/JwtUtilsTests.java
+++ b/src/test/java/io/nats/client/support/JwtUtilsTests.java
@@ -24,6 +24,8 @@ import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
+import java.util.Map;
+import java.util.HashMap;
 
 import static io.nats.json.JsonWriteUtils.beginJson;
 import static io.nats.json.JsonWriteUtils.endJson;
@@ -406,6 +408,29 @@ public class JwtUtilsTests {
         rp2.expires(1);
         assertEquals(rp1, rp2);
         assertNull(ResponsePermission.optionalInstance(null));
+    }
+
+    @Test
+    public void testVerifiedClaimsParseIsSuccessful(){
+        Map<String, JsonValue> clientTlsMap = new HashMap<>();
+        clientTlsMap.put("cipher", new JsonValue("TLS_AES_128_GCM_SHA256"));
+        clientTlsMap.put("version", new JsonValue("1.3"));
+
+        JsonValue cert = new JsonValue("-----BEGIN CERTIFICATE-----\n" +
+          "MIIFzzCCA7egAwIBAgIUTl3VZWhRLhM9XzhfzeAfHKGBgNgwDQYJKoZIhvcNAQEL\n" +
+          "-----END CERTIFICATE-----\n");
+        JsonValue certList = new JsonValue(Arrays.asList(cert));
+        List<JsonValue> groupList = Arrays.asList(certList);
+        clientTlsMap.put("verified_chains", new JsonValue(groupList));
+        JsonValue jv = new JsonValue(clientTlsMap);
+
+        ClientTls clientTls = new ClientTls(jv);
+
+        assertEquals("TLS_AES_128_GCM_SHA256", clientTls.cipher);
+        assertEquals("1.3", clientTls.version);
+        assertEquals(1, clientTls.verifiedChains.size());
+        assertEquals(1, clientTls.verifiedChains.get(0).size());
+
     }
 
     @Test


### PR DESCRIPTION
What changes have been done:
The verifiedChains property being sent as part of the AuthorizationRequest -> ClientTls -> verifiedChains was not being populated into the model. The changes done are to populate the verifiedChains property

Why this change is required?
As part of the Auth Callout, if the service performing the auth callout needs to validate the tlsCertificates, it was not available as part of the deserialization process (i.e) in raw message, the details were available but was not set in the POJO.